### PR TITLE
Fixed and renamed FileStatus.getAllFiles command.

### DIFF
--- a/src/app/Fake.Tools.Git/FileStatus.fs
+++ b/src/app/Fake.Tools.Git/FileStatus.fs
@@ -39,8 +39,8 @@ let getChangedFiles repositoryDir revision1 revision2 =
             FileStatus.Parse a.[0],a.[1])
 
 /// Gets all changed files in the current revision
-let getAllFiles repositoryDir =
-    let _,msg,_ = runGitCommand repositoryDir <| sprintf "ls-files"
+let getAllModifiedFiles repositoryDir =
+    let _,msg,_ = runGitCommand repositoryDir <| sprintf "ls-files --modified"
     msg
       |> Seq.map (fun line -> Added,line)
 


### PR DESCRIPTION
According to documentation command should list all modified files in repository. It listed all files.
- According to issue #2243

