### PR TITLE
Fixed getAllFiles doc comment.

### DIFF
--- a/src/app/Fake.Tools.Git/FileStatus.fs
+++ b/src/app/Fake.Tools.Git/FileStatus.fs
@@ -38,7 +38,7 @@ let getChangedFiles repositoryDir revision1 revision2 =
             let a = line.Split('\t')
             FileStatus.Parse a.[0],a.[1])
 
-/// Gets all changed files in the current revision
+/// Gets all files in the current repository
 let getAllFiles repositoryDir =
     let _,msg,_ = runGitCommand repositoryDir <| sprintf "ls-files"
     msg


### PR DESCRIPTION
getAllFiles was returning all files, not only modified ones.
- According to issue #2243